### PR TITLE
Check for boot2docker >= 1.3.0. Closes #1

### DIFF
--- a/R/boot2docker.R
+++ b/R/boot2docker.R
@@ -6,6 +6,9 @@ boot2docker_shellinit <- function() {
   if (Sys.which("boot2docker") == "")
     return()
 
+  if (boot2docker_ver() < "1.3.0")
+    stop("Running boot2docker locally requires boot2docker >= 1.3.0")
+
   # Run shellinit and capture the output, which are comands setting env vars
   # for sh. We need read them in and set them from R.
   envvars <- system2("boot2docker", "shellinit", stdout = TRUE)
@@ -15,4 +18,10 @@ boot2docker_shellinit <- function() {
     envvars <- setNames(pluck(envvars, 2), pluck(envvars, 1))
     do.call(Sys.setenv, envvars)
   }
+}
+
+boot2docker_ver <- function(){
+  out <- system2("boot2docker", "version", stdout = TRUE)
+  ver <- gsub("^.*?v([0-9\\.]+).*", "\\1", out[1])
+  as.package_version(ver)
 }


### PR DESCRIPTION
@sckott Does this look right?

This will give a spurious error when someone wants to use harbor on a remote machine but has an old version of boot2docker installed locally, but I think that's not a big deal, and it'll get smaller with time as people upgrade.